### PR TITLE
Fix CORS misconfiguration: remove AllowCredentials with wildcard origin

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,13 @@ func main() {
 	r.Use(middleware.Compress(5))
 
 	r.Use(cors.New(cors.Options{
-		AllowCredentials:   true,
+		// AllowCredentials must be false when AllowedOrigins is ["*"].
+		// Combining a wildcard origin with credentials causes go-chi/cors to
+		// reflect the incoming Origin header, allowing any site to make
+		// credentialed cross-origin requests (CORS bypass). The reporting and
+		// analytics endpoints receive anonymous browser telemetry only and do
+		// not rely on cookies or session tokens.
+		AllowCredentials:   false,
 		OptionsPassthrough: true,
 		AllowedOrigins:     []string{"*"},
 		AllowedMethods:     []string{"GET", "POST", "OPTIONS"},
@@ -586,10 +592,10 @@ func apiReportsHandler(pgDB *gorm.DB) http.HandlerFunc {
 		}
 
 		out := struct {
-			Counts         []db.ReportDailyCount     `json:"counts"`
-			RecentReports  []db.SecurityReportEntry   `json:"recent_reports"`
-			RecentReportTo []db.ReportToEntry         `json:"recent_report_to"`
-			TopDirectives  []db.DirectiveCount        `json:"top_directives"`
+			Counts         []db.ReportDailyCount   `json:"counts"`
+			RecentReports  []db.SecurityReportEntry `json:"recent_reports"`
+			RecentReportTo []db.ReportToEntry       `json:"recent_report_to"`
+			TopDirectives  []db.DirectiveCount      `json:"top_directives"`
 		}{
 			Counts:         counts,
 			RecentReports:  recent,


### PR DESCRIPTION
## Problem

`main.go` configured CORS with both a wildcard origin and credentials:

```go
r.Use(cors.New(cors.Options{
    AllowCredentials:   true,       // ← problem
    AllowedOrigins:     []string{"*"},
    // ...
}).Handler)
```

Per the [CORS specification](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials), `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Credentials: true` cannot be used together — browsers reject this combination.

The `go-chi/cors` library (v1.2.2) works around this by **reflecting the incoming `Origin` header** as `Access-Control-Allow-Origin` whenever `AllowCredentials` is `true` (instead of sending `*`). This means:

- Any website that makes a cross-origin request to `reportd.natwelch.com` will receive a response with `Access-Control-Allow-Origin: <their-origin>` and `Access-Control-Allow-Credentials: true`
- This effectively allows **any origin** to make credentialed cross-origin requests
- If session cookies or `Authorization` headers are ever added to this service, **any site on the internet could steal them**

This is a CORS misconfiguration (CWE-942: Overly Permissive Cross-domain Whitelist).

## Root cause

`AllowCredentials: true` was set alongside `AllowedOrigins: []string{"*"}`. The intent was likely to allow any site to POST browser telemetry (CSP reports, Web Vitals), but credentials are not needed for that use case.

## Fix

Set `AllowCredentials: false`. The reporting and analytics endpoints receive anonymous browser telemetry only — no cookies or session tokens are involved. The wildcard origin is still correct and intentional.

## Testing steps

1. Deploy the change
2. Send a preflight `OPTIONS` request from a browser (or `curl`): `curl -H "Origin: https://evil.example.com" -H "Access-Control-Request-Method: POST" -X OPTIONS https://reportd.natwelch.com/report/test -v`
3. Verify the response does **not** include `Access-Control-Allow-Credentials: true`
4. Verify CSP reports still arrive correctly from production sites

## What was reviewed / skipped this run

| Area | Finding | Action |
|------|---------|--------|
| CORS config | `AllowCredentials: true` + wildcard origin | **Fixed (this PR)** |
| Dockerfile | No `USER` instruction in final stage (runs as root) | Skip for now — low exploitability for a server-side service; worth a future PR |
| `go.mod` | All dependencies appear current (Go 1.25, chi v5.2.5, gorm v1.31.1) | No action needed |
| Request body size limit | No `http.MaxBytesReader` on POST endpoints — could allow large payloads | Medium finding — worth a future PR |
| Auth | No authentication on any endpoint | Intentional for a public reporting sink; documented |
