### PR TITLE
fix: address golangci-lint findings

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -82,7 +82,7 @@ func newTestRouter(t *testing.T) (http.Handler, *gorm.DB, *recordingWriters) {
 
 func do(t *testing.T, h http.Handler, method, target string, body io.Reader, contentType string) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(method, target, body)
+	req := httptest.NewRequestWithContext(t.Context(), method, target, body)
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -41,6 +41,7 @@ type WebVital struct {
 	Service bigquery.NullString
 }
 
+// Validate returns an error if Service is unset or empty.
 func (wv *WebVital) Validate() error {
 	if !wv.Service.Valid {
 		return fmt.Errorf("service is null")

--- a/pkg/db/convert.go
+++ b/pkg/db/convert.go
@@ -103,8 +103,8 @@ func SecurityReportEntryFromReport(sr *reporting.SecurityReport) *SecurityReport
 	switch {
 	case sr.CSP != nil:
 		entry.URL = sr.CSP.URL
-		entry.DocumentURI = sr.CSP.Body.DocumentUri
-		entry.BlockedURI = sr.CSP.Body.BlockedUri
+		entry.DocumentURI = sr.CSP.Body.DocumentURI
+		entry.BlockedURI = sr.CSP.Body.BlockedURI
 		entry.ViolatedDirective = sr.CSP.Body.ViolatedDirective
 		entry.EffectiveDirective = sr.CSP.Body.EffectiveDirective
 		entry.SourceFile = sr.CSP.Body.SourceFile

--- a/pkg/db/convert_test.go
+++ b/pkg/db/convert_test.go
@@ -124,7 +124,7 @@ func TestReportToEntryFromExpectCT(t *testing.T) {
 func TestReportToEntryFromReportTo(t *testing.T) {
 	r := &reportto.Report{
 		Service: bigquery.NullString{StringVal: "mysite", Valid: true},
-		ReportTo: []*reportto.ReportToReport{
+		ReportTo: []*reportto.Entry{
 			{
 				Type: "csp-violation",
 				URL:  "https://example.com/page",
@@ -201,8 +201,8 @@ func TestSecurityReportEntryFromCSP(t *testing.T) {
 		CSP: &reporting.CSPReport{
 			URL: "https://example.com/",
 			Body: reporting.CSPReportBody{
-				DocumentUri:        "https://example.com/page",
-				BlockedUri:         testBlockedURI,
+				DocumentURI:        "https://example.com/page",
+				BlockedURI:         testBlockedURI,
 				EffectiveDirective: "script-src-elem",
 				SourceFile:         "app.js",
 				LineNumber:         42,
@@ -331,7 +331,7 @@ func TestSecurityReportEntryFromDocumentPolicy(t *testing.T) {
 		DocumentPolicy: &reporting.DocumentPolicyReport{
 			URL: "https://example.com/",
 			Body: reporting.DocumentPolicyReportBody{
-				FeatureId:  "oversized-images",
+				FeatureID:  "oversized-images",
 				Message:    "Image too large",
 				SourceFile: "index.html",
 				LineNumber: 15,
@@ -360,7 +360,7 @@ func TestSecurityReportEntryFromPermissionsPolicy(t *testing.T) {
 		PermissionsPolicy: &reporting.PermissionsPolicyReport{
 			URL: "https://example.com/",
 			Body: reporting.PermissionsPolicyReportBody{
-				FeatureId:  "geolocation",
+				FeatureID:  "geolocation",
 				Message:    "geolocation not allowed",
 				SourceFile: "app.js",
 				LineNumber: 42,
@@ -386,7 +386,7 @@ func TestSecurityReportEntryFromIntervention(t *testing.T) {
 		Intervention: &reporting.InterventionReport{
 			URL: "https://example.com/",
 			Body: reporting.InterventionReportBody{
-				Id:         "HeavyAdIntervention",
+				ID:         "HeavyAdIntervention",
 				Message:    "Ad removed",
 				SourceFile: "ads.js",
 				LineNumber: 100,

--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -20,9 +20,9 @@ type CSPReport struct {
 
 // CSPReportBody is the body of a CSPReport.
 type CSPReportBody struct {
-	DocumentUri        string `json:"document_uri,omitempty"`
+	DocumentURI        string `json:"document_uri,omitempty"`
 	Referrer           string `json:"referrer,omitempty"`
-	BlockedUri         string `json:"blocked_uri,omitempty"`
+	BlockedURI         string `json:"blocked_uri,omitempty"`
 	ViolatedDirective  string `json:"violated_directive,omitempty"`
 	EffectiveDirective string `json:"effective_directive,omitempty"`
 	OriginalPolicy     string `json:"original_policy,omitempty"`
@@ -43,9 +43,9 @@ type DeprecationReport struct {
 // existing BigQuery columns keep type-checking; new fields are nullable.
 type DeprecationReportBody struct {
 	// Legacy fields kept for BigQuery column compatibility.
-	DocumentUri        string `json:"document_uri,omitempty"`
+	DocumentURI        string `json:"document_uri,omitempty"`
 	Referrer           string `json:"referrer,omitempty"`
-	BlockedUri         string `json:"blocked_uri,omitempty"`
+	BlockedURI         string `json:"blocked_uri,omitempty"`
 	ViolatedDirective  string `json:"violated_directive,omitempty"`
 	EffectiveDirective string `json:"effective_directive,omitempty"`
 	OriginalPolicy     string `json:"original_policy,omitempty"`
@@ -55,7 +55,7 @@ type DeprecationReportBody struct {
 	ScriptSample       string `json:"script_sample,omitempty"`
 
 	// Populated manually in ParseReport via a sibling decode (json:"-").
-	Id                 bigquery.NullString `json:"-"`
+	ID                 bigquery.NullString `json:"-"`
 	AnticipatedRemoval bigquery.NullString `json:"-"`
 	Message            bigquery.NullString `json:"-"`
 }
@@ -69,7 +69,7 @@ type PermissionsPolicyReport struct {
 
 // PermissionsPolicyReportBody is the body of a PermissionsPolicyReport.
 type PermissionsPolicyReportBody struct {
-	FeatureId    string `json:"featureId,omitempty"`
+	FeatureID    string `json:"featureId,omitempty"`
 	SourceFile   string `json:"sourceFile,omitempty"`
 	LineNumber   int32  `json:"lineNumber,omitempty"`
 	ColumnNumber int32  `json:"columnNumber,omitempty"`
@@ -87,7 +87,7 @@ type InterventionReport struct {
 
 // InterventionReportBody is the body of an InterventionReport.
 type InterventionReportBody struct {
-	Id           string `json:"id,omitempty"`
+	ID           string `json:"id,omitempty"`
 	Message      string `json:"message,omitempty"`
 	SourceFile   string `json:"sourceFile,omitempty"`
 	LineNumber   int32  `json:"lineNumber,omitempty"`
@@ -147,7 +147,7 @@ type DocumentPolicyReport struct {
 
 // DocumentPolicyReportBody is the body of a DocumentPolicyReport.
 type DocumentPolicyReportBody struct {
-	FeatureId    string `json:"featureId,omitempty"`
+	FeatureID    string `json:"featureId,omitempty"`
 	SourceFile   string `json:"sourceFile,omitempty"`
 	LineNumber   int32  `json:"lineNumber,omitempty"`
 	ColumnNumber int32  `json:"columnNumber,omitempty"`
@@ -212,13 +212,13 @@ func ParseReport(data, srv string) (*SecurityReport, error) {
 		// Populate NullString fields that json:"-" skips.
 		var depJSON struct {
 			Body struct {
-				Id                 string `json:"id"`
+				ID                 string `json:"id"`
 				AnticipatedRemoval string `json:"anticipated_removal"`
 				Message            string `json:"message"`
 			} `json:"body"`
 		}
 		if err := json.Unmarshal([]byte(data), &depJSON); err == nil {
-			sr.Deprecation.Body.Id = bigquery.NullString{StringVal: depJSON.Body.Id, Valid: depJSON.Body.Id != ""}
+			sr.Deprecation.Body.ID = bigquery.NullString{StringVal: depJSON.Body.ID, Valid: depJSON.Body.ID != ""}
 			sr.Deprecation.Body.AnticipatedRemoval = bigquery.NullString{StringVal: depJSON.Body.AnticipatedRemoval, Valid: depJSON.Body.AnticipatedRemoval != ""}
 			sr.Deprecation.Body.Message = bigquery.NullString{StringVal: depJSON.Body.Message, Valid: depJSON.Body.Message != ""}
 		}

--- a/pkg/reporting/reporting_test.go
+++ b/pkg/reporting/reporting_test.go
@@ -85,8 +85,8 @@ func TestParseCSPViolation(t *testing.T) {
 	if data.CSP.URL != "https://example.com/" {
 		t.Errorf("expected URL 'https://example.com/', got %q", data.CSP.URL)
 	}
-	if data.CSP.Body.BlockedUri != "https://evil.com/script.js" {
-		t.Errorf("expected blocked_uri 'https://evil.com/script.js', got %q", data.CSP.Body.BlockedUri)
+	if data.CSP.Body.BlockedURI != "https://evil.com/script.js" {
+		t.Errorf("expected blocked_uri 'https://evil.com/script.js', got %q", data.CSP.Body.BlockedURI)
 	}
 	if data.CSP.Body.EffectiveDirective != "script-src-elem" {
 		t.Errorf("expected effective_directive 'script-src-elem', got %q", data.CSP.Body.EffectiveDirective)
@@ -120,8 +120,8 @@ func TestParseDeprecation(t *testing.T) {
 	if data.Deprecation == nil {
 		t.Fatal("Deprecation should not be nil")
 	}
-	if data.Deprecation.Body.Id.StringVal != "websql" {
-		t.Errorf("expected id 'websql', got %q", data.Deprecation.Body.Id.StringVal)
+	if data.Deprecation.Body.ID.StringVal != "websql" {
+		t.Errorf("expected id 'websql', got %q", data.Deprecation.Body.ID.StringVal)
 	}
 	if data.Deprecation.Body.Message.StringVal != "WebSQL is deprecated" {
 		t.Errorf("expected message 'WebSQL is deprecated', got %q", data.Deprecation.Body.Message.StringVal)
@@ -153,8 +153,8 @@ func TestParsePermissionsPolicy(t *testing.T) {
 	if data.PermissionsPolicy == nil {
 		t.Fatal("PermissionsPolicy should not be nil")
 	}
-	if data.PermissionsPolicy.Body.FeatureId != "camera" {
-		t.Errorf("expected featureId 'camera', got %q", data.PermissionsPolicy.Body.FeatureId)
+	if data.PermissionsPolicy.Body.FeatureID != "camera" {
+		t.Errorf("expected featureId 'camera', got %q", data.PermissionsPolicy.Body.FeatureID)
 	}
 	if data.PermissionsPolicy.Body.Disposition != "enforce" {
 		t.Errorf("expected disposition 'enforce', got %q", data.PermissionsPolicy.Body.Disposition)
@@ -188,8 +188,8 @@ func TestParseIntervention(t *testing.T) {
 	if data.Intervention == nil {
 		t.Fatal("Intervention should not be nil")
 	}
-	if data.Intervention.Body.Id != "HeavyAdIntervention" {
-		t.Errorf("expected id 'HeavyAdIntervention', got %q", data.Intervention.Body.Id)
+	if data.Intervention.Body.ID != "HeavyAdIntervention" {
+		t.Errorf("expected id 'HeavyAdIntervention', got %q", data.Intervention.Body.ID)
 	}
 	if data.Intervention.Body.Message != "Ad removed for CPU usage" {
 		t.Errorf("expected message 'Ad removed for CPU usage', got %q", data.Intervention.Body.Message)
@@ -309,8 +309,8 @@ func TestParseDocumentPolicy(t *testing.T) {
 	if data.DocumentPolicy == nil {
 		t.Fatal("DocumentPolicy should not be nil")
 	}
-	if data.DocumentPolicy.Body.FeatureId != "oversized-images" {
-		t.Errorf("expected featureId 'oversized-images', got %q", data.DocumentPolicy.Body.FeatureId)
+	if data.DocumentPolicy.Body.FeatureID != "oversized-images" {
+		t.Errorf("expected featureId 'oversized-images', got %q", data.DocumentPolicy.Body.FeatureID)
 	}
 	if data.DocumentPolicy.Body.Message != "Image exceeds size limit" {
 		t.Errorf("expected message 'Image exceeds size limit', got %q", data.DocumentPolicy.Body.Message)
@@ -604,8 +604,8 @@ func TestParseReportDeprecationNullStringFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !data.Deprecation.Body.Id.Valid || data.Deprecation.Body.Id.StringVal != "websql" {
-		t.Errorf("expected id 'websql', got %+v", data.Deprecation.Body.Id)
+	if !data.Deprecation.Body.ID.Valid || data.Deprecation.Body.ID.StringVal != "websql" {
+		t.Errorf("expected id 'websql', got %+v", data.Deprecation.Body.ID)
 	}
 	if !data.Deprecation.Body.AnticipatedRemoval.Valid || data.Deprecation.Body.AnticipatedRemoval.StringVal != "2025-01-01" {
 		t.Errorf("expected anticipated_removal '2025-01-01', got %+v", data.Deprecation.Body.AnticipatedRemoval)
@@ -622,7 +622,7 @@ func TestParseReportDeprecationEmptyNullFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if data.Deprecation.Body.Id.Valid {
+	if data.Deprecation.Body.ID.Valid {
 		t.Error("id should not be valid when missing")
 	}
 	if data.Deprecation.Body.AnticipatedRemoval.Valid {

--- a/pkg/reportto/reports.go
+++ b/pkg/reportto/reports.go
@@ -25,7 +25,7 @@ const (
 type Report struct {
 	ExpectCT *ExpectCTReport `bigquery:",nullable"`
 	CSP      *CSPReport      `bigquery:",nullable"`
-	ReportTo []*ReportToReport
+	ReportTo []*Entry
 
 	Time bigquery.NullDateTime
 
@@ -78,11 +78,11 @@ type CSPReport struct {
 	} `json:"csp-report"`
 }
 
-// ReportToReport is one entry of an application/reports+json payload.
+// Entry is one entry of an application/reports+json payload.
 // Body is a superset of fields observed across browsers.
 //
 // TODO: browsers send status under multiple names — normalize.
-type ReportToReport struct {
+type Entry struct {
 	Type      string `json:"type"`
 	Age       int    `json:"age"`
 	URL       string `json:"url"`
@@ -131,7 +131,7 @@ func ParseReport(ct, body, srv string) (*Report, error) {
 
 	switch media {
 	case ContentTypeReports:
-		var data []*ReportToReport
+		var data []*Entry
 		if err := json.Unmarshal([]byte(body), &data); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
The new golangci-lint workflow added stricter linters. This PR fixes the findings so the lint check passes.

## Changes
- **noctx** (`main_test.go`): switch `httptest.NewRequest` to `httptest.NewRequestWithContext(t.Context(), ...)` in the test helper.
- **revive** `exported`: add the missing doc comment on `(*WebVital).Validate`.
- **revive** `var-naming` (`pkg/reporting/reporting.go`): rename `DocumentUri`/`BlockedUri` -> `DocumentURI`/`BlockedURI` (CSP and Deprecation bodies), `FeatureId` -> `FeatureID` (PermissionsPolicy and DocumentPolicy bodies), and `Id` -> `ID` (Deprecation, Intervention bodies + the local anon struct in `ParseReport`). Updated all in-tree call sites in `pkg/db/convert.go`, `pkg/db/convert_test.go`, and `pkg/reporting/reporting_test.go`.
- **revive** `exported` stutter (`pkg/reportto/reports.go`): rename `ReportToReport` -> `Entry` since the package is already `reportto`; updated the one external caller in `pkg/db/convert_test.go`.

## Verification
- `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert ./...` -- 0 issues
- `go build ./...` -- passes
- `go test ./...` -- passes (all packages)

Generated with [Claude Code](https://claude.com/claude-code)