### PR TITLE
fix: detach ingest writes from the request context

### DIFF
--- a/main.go
+++ b/main.go
@@ -402,10 +402,9 @@ func getReportsHandler(pgDB *gorm.DB) http.HandlerFunc {
 	}
 }
 
-// ingestContext detaches a request context for a write that has to outlive the
-// request. Browsers send to the ingest endpoints with navigator.sendBeacon or
-// on page unload, so the connection is routinely torn down mid-insert and
-// r.Context() gets cancelled out from under the write.
+// ingestContext detaches a request context so a write survives the client
+// hanging up. Beacons are sent on page unload, so the connection is routinely
+// torn down mid-insert.
 func ingestContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 }

--- a/main.go
+++ b/main.go
@@ -402,6 +402,14 @@ func getReportsHandler(pgDB *gorm.DB) http.HandlerFunc {
 	}
 }
 
+// ingestContext detaches a request context for a write that has to outlive the
+// request. Browsers send to the ingest endpoints with navigator.sendBeacon or
+// on page unload, so the connection is routinely torn down mid-insert and
+// r.Context() gets cancelled out from under the write.
+func ingestContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+}
+
 func postReportHandler(pgDB *gorm.DB, writeBQ reportToBQWriter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -433,7 +441,9 @@ func postReportHandler(pgDB *gorm.DB, writeBQ reportToBQWriter) http.HandlerFunc
 		l.Infow("report received", "content-type", ct, "service", service, "user-agent", r.UserAgent(), "report", data)
 
 		entries := db.ReportToEntriesFromReport(data)
-		if err := pgDB.WithContext(ctx).Create(&entries).Error; err != nil {
+		writeCtx, cancel := ingestContext(ctx)
+		defer cancel()
+		if err := pgDB.WithContext(writeCtx).Create(&entries).Error; err != nil {
 			l.Errorw("error writing report to postgres", zap.Error(err), "service", service)
 			http.Error(w, "storage error", 500)
 			return
@@ -520,7 +530,9 @@ func postAnalyticsHandler(pgDB *gorm.DB, writeBQ analyticsBQWriter) http.Handler
 		l.Infow("analytics received", "content-type", ct, "service", service, "user-agent", r.UserAgent(), "analytics", data)
 
 		entry := db.WebVitalFromAnalytics(data)
-		if err := pgDB.WithContext(ctx).Create(entry).Error; err != nil {
+		writeCtx, cancel := ingestContext(ctx)
+		defer cancel()
+		if err := pgDB.WithContext(writeCtx).Create(entry).Error; err != nil {
 			l.Errorw("error writing analytics to postgres", zap.Error(err), "service", service)
 			http.Error(w, "storage error", 500)
 			return
@@ -582,7 +594,9 @@ func postReportingHandler(pgDB *gorm.DB, writeBQ securityReportBQWriter) http.Ha
 		l.Infow("reporting parsed", "reports", reports, "service", service, "content-type", contentType, "user-agent", r.UserAgent())
 
 		entry := db.SecurityReportEntryFromReport(reports)
-		if err := pgDB.WithContext(ctx).Create(entry).Error; err != nil {
+		writeCtx, cancel := ingestContext(ctx)
+		defer cancel()
+		if err := pgDB.WithContext(writeCtx).Create(entry).Error; err != nil {
 			l.Errorw("error writing reporting to postgres", zap.Error(err), "service", service)
 			http.Error(w, "storage error", 500)
 			return


### PR DESCRIPTION
The three ingest handlers pass `r.Context()` straight into the postgres insert. Browsers hit these with `navigator.sendBeacon` or on page unload, so the connection is routinely torn down before the insert finishes and the write is cancelled — the row is lost and we log:

```
error writing analytics to postgres ... "error":"context canceled"
```

9 of 2644 analytics beacons dropped this way in the last 24h on mist.

The BigQuery writes in these same handlers already use `context.WithoutCancel`; this does the same for postgres, with a 10s timeout so a detached write can't hang forever.