### PR TITLE
fix: replace archived namsral/flag with peterbourgon/ff

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -16,20 +17,20 @@ import (
 	"github.com/icco/reportd/pkg/db"
 	"github.com/icco/reportd/pkg/reporting"
 	"github.com/icco/reportd/pkg/reportto"
-	"github.com/namsral/flag"
+	"github.com/peterbourgon/ff/v3"
 	"google.golang.org/api/iterator"
 	"gorm.io/gorm"
 )
 
 func main() {
-	fs := flag.NewFlagSetWithEnvPrefix(os.Args[0], "REPORTD", 0)
+	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	project := fs.String("project", "", "GCP project ID")
 	dataset := fs.String("dataset", "", "BigQuery dataset")
 	aTable := fs.String("analytics_table", "", "BQ analytics table name")
 	rTable := fs.String("reports_table", "", "BQ reports table name")
 	rv2Table := fs.String("reports_v2_table", "", "BQ reporting (v2) table name")
 	databaseURL := fs.String("database_url", "", "Database connection string")
-	if err := fs.Parse(os.Args[1:]); err != nil {
+	if err := ff.Parse(fs, os.Args[1:], ff.WithEnvVarPrefix("REPORTD")); err != nil {
 		log.Fatalf("parsing flags: %v", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-chi/chi/v5 v5.3.2
 	github.com/go-chi/cors v1.2.2
 	github.com/icco/gutil v1.0.11
-	github.com/namsral/flag v1.7.4-pre
+	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/unrolled/render v1.7.0
 	github.com/unrolled/secure v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/mattn/go-sqlite3 v1.14.50 h1:dmdFvo1XG4MPzA4IkAmE9upVz/Nj31uRoM5+jC8h
 github.com/mattn/go-sqlite3 v1.14.50/go.mod h1:6JTjA44L93a0QCyJef5YvlPoKXntQPjzWv5gtm9sB6w=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/namsral/flag v1.7.4-pre h1:b2ScHhoCUkbsq0d2C15Mv+VU8bl8hAXV8arnWiOHNZs=
-github.com/namsral/flag v1.7.4-pre/go.mod h1:OXldTctbM6SWH1K899kPZcf65KxJiD7MsceFUpB5yDo=
+github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=
+github.com/peterbourgon/ff/v3 v3.4.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
 github.com/pierrec/lz4/v4 v4.1.29 h1:CDQY6qZOLI4DW0Nx6R1vRrifrCeQHnNXkMb0hZWXFjg=
 github.com/pierrec/lz4/v4 v4.1.29/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io/fs"
 	"mime"
@@ -26,7 +27,7 @@ import (
 	"github.com/icco/reportd/pkg/reporting"
 	"github.com/icco/reportd/pkg/reportto"
 	"github.com/icco/reportd/templates"
-	"github.com/namsral/flag"
+	"github.com/peterbourgon/ff/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/unrolled/render"
@@ -74,14 +75,14 @@ func routeTag(next http.Handler) http.Handler {
 }
 
 func main() {
-	fs := flag.NewFlagSetWithEnvPrefix(os.Args[0], "REPORTD", 0)
+	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	project := fs.String("project", "", "Project ID containing the bigquery dataset to upload to.")
 	dataset := fs.String("dataset", "", "The bigquery dataset to upload to.")
 	aTable := fs.String("analytics_table", "", "The bigquery table to upload analytics to.")
 	rTable := fs.String("reports_table", "", "The bigquery table to upload reports to.")
 	rv2Table := fs.String("reports_v2_table", "", "The bigquery table to upload reports to.")
 	databaseURL := fs.String("database_url", "", "Database connection string (e.g. postgres://user:pass@host/reportd or sqlite:///tmp/reportd.db).")
-	if err := fs.Parse(os.Args[1:]); err != nil {
+	if err := ff.Parse(fs, os.Args[1:], ff.WithEnvVarPrefix("REPORTD")); err != nil {
 		log.Fatalw("error parsing flags", zap.Error(err))
 	}
 


### PR DESCRIPTION
`namsral/flag` is archived upstream (last push 2023-05) and has no tagged release. `peterbourgon/ff` does the same job — flags, then env vars, then optional config files — and layers on a stdlib `*flag.FlagSet`, so this is a mechanical swap.

- `flag.NewFlagSetWithEnvPrefix(os.Args[0], "REPORTD", 0)` → `flag.NewFlagSet(os.Args[0], flag.ContinueOnError)` (`0` was `ContinueOnError`; both call sites already handle the returned error)
- `fs.Parse(os.Args[1:])` → `ff.Parse(fs, os.Args[1:], ff.WithEnvVarPrefix("REPORTD"))`

**Env var names are unchanged.** Both libraries derive the key the same way: uppercase the flag name, `-` → `_`, prefix with `REPORTD_`. No README, Dockerfile, or deploy changes needed.

Pinned to v3.4.0, ff's current release; v4 is still `v4.0.0-beta.1`. The root `ff` package pulls in no third-party deps (its toml/yaml requirements are only for the `fftoml`/`ffyaml` subpackages), so `go.mod` and `go.sum` show a straight one-for-one swap.

Verified locally: `go build`, `go test ./...`, `go vet`, plus running both binaries with env vars only, flags only, and neither (still fatals on the required-flag checks).
