### PR TITLE
style: trim golangci config header comment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # Committed rather than passed as CI flags so local and CI enforce the same set.
-# Comments sit on their own lines: the yaml-json format job runs `yq -iP`, which
-# collapses the two spaces yamllint wants before an inline comment.
+# Comments go on their own lines: the yaml-json format job's yq collapses the
+# inline spacing yamllint wants.
 # https://golangci-lint.run/docs/configuration/file/
 version: "2"
 linters:


### PR DESCRIPTION
Comment-only follow-up to #214, which merged before this landed.

Trims the header note about comment placement from three lines to two. The convention itself is unchanged and still worth recording: `yq -iP` in the yaml-json format job collapses the two spaces yamllint wants before an inline comment, and `.golangci.yml` is not under `.github/workflows`, so the bot would commit the collapse and the warning would return. Own-line comments are stable under both.

Verified `yamllint -s` clean, stable under `yq -iP`, and `golangci-lint config verify` valid.